### PR TITLE
Add Abstract I2C Interface to Support Multiple SW35xx Devices

### DIFF
--- a/examples/SimpleTest/SimpleTest.ino
+++ b/examples/SimpleTest/SimpleTest.ino
@@ -1,8 +1,17 @@
 #include <Arduino.h>
+#include <SoftwareWire.h>
 #include <h1_SW35xx.h>
+#include "SoftwareWireWrapper.h"
+
+
 using namespace h1_SW35xx;
 
-SW35xx sw(Wire);
+// Create a SoftwareWire instance (choose your SDA and SCL pins)
+SoftwareWire softWire(2, 3);
+// Wrap the SoftwareWire instance
+SoftwareWireWrapper softWrapper(softWire);
+// Instantiate the SW35xx device with the wrapper
+SW35xx device(softWrapper);
 
 const char *fastChargeType2String(SW35xx::fastChargeType_t fastChargeType) {
   switch (fastChargeType) {
@@ -50,21 +59,16 @@ const char *fastChargeType2String(SW35xx::fastChargeType_t fastChargeType) {
 
 void setup() {
   Serial.begin(115200);
-  Wire.begin(D1, D2); 
-  sw.setMaxCurrent5A();
+  softWrapper.begin(); // Initialize the SoftwareWire bus
+  device.begin();
+  Serial.println("SW35xx device initialized using SoftwareWire.");
 }
 
 void loop() {
-  sw.readStatus();
-  Serial.println("=======================================");
-  Serial.printf("Current input voltage:%dmV\n", sw.vin_mV);
-  Serial.printf("Current output voltage:%dmV\n", sw.vout_mV);
-  Serial.printf("Current USB-C current:%dmA\r\n", sw.iout_usbc_mA);
-  Serial.printf("Current USB-A current:%dmA\r\n", sw.iout_usba_mA);
-  Serial.printf("Current fast charge type:%s\n", fastChargeType2String(sw.fastChargeType));
-  if (sw.fastChargeType == SW35xx::PD_FIX || sw.fastChargeType == SW35xx::PD_PPS)
-    Serial.printf("Current PD version:%d\n", sw.PDVersion);
-  Serial.println("=======================================");
-  Serial.println("");
+  device.readStatus();
+  Serial.print("Input Voltage: ");
+  Serial.print(device.vin_mV);
+  Serial.println(" mV");
+  // … print other values as needed
   delay(2000);
 }

--- a/src/I2CInterface.h
+++ b/src/I2CInterface.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <stdint.h>
+
+class I2CInterface {
+public:
+  virtual void begin() = 0;
+  virtual void beginTransmission(uint8_t address) = 0;
+  virtual size_t write(uint8_t data) = 0;
+  virtual uint8_t endTransmission() = 0;
+  virtual size_t requestFrom(uint8_t address, size_t quantity) = 0;
+  virtual int available() = 0;
+  virtual int read() = 0;
+};

--- a/src/SoftwareWireWrapper.h
+++ b/src/SoftwareWireWrapper.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <SoftwareWire.h>
+#include "I2CInterface.h"
+
+class SoftwareWireWrapper : public I2CInterface {
+public:
+  SoftwareWireWrapper(SoftwareWire &w) : softWire(w) {}
+  void begin() override { softWire.begin(); }
+  void beginTransmission(uint8_t address) override { softWire.beginTransmission(address); }
+  size_t write(uint8_t data) override { return softWire.write(data); }
+  uint8_t endTransmission() override { return softWire.endTransmission(); }
+  size_t requestFrom(uint8_t address, size_t quantity) override { return softWire.requestFrom(address, quantity); }
+  int available() override { return softWire.available(); }
+  int read() override { return softWire.read(); }
+private:
+  SoftwareWire &softWire;
+};

--- a/src/TwoWireWrapper.h
+++ b/src/TwoWireWrapper.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <Wire.h>
+#include "I2CInterface.h"
+
+class TwoWireWrapper : public I2CInterface {
+public:
+  TwoWireWrapper(TwoWire &w) : wire(w) {}
+  void begin() override { wire.begin(); }
+  void beginTransmission(uint8_t address) override { wire.beginTransmission(address); }
+  size_t write(uint8_t data) override { return wire.write(data); }
+  uint8_t endTransmission() override { return wire.endTransmission(); }
+  size_t requestFrom(uint8_t address, size_t quantity) override { return wire.requestFrom(address, quantity); }
+  int available() override { return wire.available(); }
+  int read() override { return wire.read(); }
+private:
+  TwoWire &wire;
+};

--- a/src/h1_SW35xx.cpp
+++ b/src/h1_SW35xx.cpp
@@ -91,6 +91,8 @@ int SW35xx::i2cWriteReg8(const uint8_t reg, const uint8_t data) {
 }
 
 void SW35xx::begin(){
+  //Add delay to avoid I2C bus error
+    delay(100);
   // Enable voltage reading
   i2cWriteReg8(SW35XX_I2C_CTRL, 0x02);
 }

--- a/src/h1_SW35xx.cpp
+++ b/src/h1_SW35xx.cpp
@@ -40,7 +40,7 @@
 
 namespace h1_SW35xx {
 
-SW35xx::SW35xx(TwoWire &i2c) : _i2c(i2c) {}
+SW35xx::SW35xx(I2CInterface &i2c) : _i2c(i2c) {}
 SW35xx::~SW35xx() {}
 
 int SW35xx::i2cReadReg8(const uint8_t reg) {
@@ -57,7 +57,7 @@ int SW35xx::i2cReadReg8(const uint8_t reg) {
       continue;
     }
 
-    /* Wait until data is available if required */
+    // Wait until data is available if required
     for (int k=0; !_i2c.available() && k<I2C_RETRIES; k++) {
       delay(10);
     }
@@ -74,7 +74,6 @@ int SW35xx::i2cReadReg8(const uint8_t reg) {
 
 int SW35xx::i2cWriteReg8(const uint8_t reg, const uint8_t data) {
   int error = -1;
-
   for (int i=0; i<I2C_RETRIES; i++) {
     _i2c.beginTransmission(SW35XX_ADDRESS);
     if (_i2c.write(reg) != 1) {
@@ -88,21 +87,18 @@ int SW35xx::i2cWriteReg8(const uint8_t reg, const uint8_t data) {
       return 0;
     }
   }
-
   return error;
 }
 
 void SW35xx::begin(){
-  //启用输入电压读取
+  // Enable voltage reading
   i2cWriteReg8(SW35XX_I2C_CTRL, 0x02);
 }
 
 uint16_t SW35xx::readADCDataBuffer(const enum ADCDataType type) {
   i2cWriteReg8(SW35XX_ADC_DATA_TYPE, type);
-
   uint16_t value = i2cReadReg8(SW35XX_ADC_DATA_BUF_H) << 4;
   value |= i2cReadReg8(SW35XX_ADC_DATA_BUF_L) | 0x0f;
-
   return value;
 }
 
@@ -113,13 +109,13 @@ void SW35xx::readStatus(const bool useADCDataBuffer) {
   uint16_t iout_usba = 0;
 
   if (useADCDataBuffer) {
-    //读取输入电压
+    // Read input voltage
     vin = readADCDataBuffer(ADC_VIN);
-    //读取输出电压
+    // Read output voltage
     vout = readADCDataBuffer(ADC_VOUT);
-    //读取接口1输出电流
+    // Read USB-C output current
     iout_usbc = readADCDataBuffer(ADC_IOUT_USB_C);
-    //读取接口2输出电流
+    // Read USB-A output current
     iout_usba = readADCDataBuffer(ADC_IOUT_USB_A);
   } else {
     const uint8_t vin_vout_low = i2cReadReg8(SW35XX_ADC_VIN_VOUT_L);
@@ -137,7 +133,7 @@ void SW35xx::readStatus(const bool useADCDataBuffer) {
 
   vin_mV = vin * 10;
   vout_mV = vout * 6;
-  if (iout_usbc > 15) //在没有输出的情况下读到的数据是15
+  if (iout_usbc > 15)
     iout_usbc_mA = iout_usbc * 5 / 2;
   else
     iout_usbc_mA = 0;
@@ -146,7 +142,8 @@ void SW35xx::readStatus(const bool useADCDataBuffer) {
     iout_usba_mA = iout_usba * 5 / 2;
   else
     iout_usba_mA = 0;
-  //读取pd版本和快充协议
+  
+  // Read PD version and fast charge protocol
   const uint8_t status = i2cReadReg8(SW35XX_FCX_STATUS);
   PDVersion = ((status & 0x30) >> 4) + 1;
   fastChargeType = (fastChargeType_t)(status & 0x0f);
@@ -154,15 +151,12 @@ void SW35xx::readStatus(const bool useADCDataBuffer) {
 
 float SW35xx::readTemperature(const bool useADCDataBuffer) {
   uint16_t temperature = 0;
-
   if (useADCDataBuffer) {
     temperature = readADCDataBuffer(ADC_TEMPERATURE);
   } else {
     temperature = i2cReadReg8(SW35XX_ADC_TS_H) << 4;
     temperature |= i2cReadReg8(SW35XX_ADC_TS_L) & 0x0F;
   }
-
-  /* return it in mV */
   return temperature * 0.5;
 }
 
@@ -198,12 +192,10 @@ void SW35xx::setMaxCurrent5A() {
 
 void SW35xx::setQuickChargeConfiguration(const uint16_t flags,
     const enum QuickChargePowerClass power) {
-  /* mask all available bits to avoid setting reserved bits */
   const uint16_t validFlags = flags & QC_CONF_ALL;
   const uint16_t validPower = power & QC_PWR_20V_2;
   const uint8_t conf1 = validFlags;
   const uint8_t conf2 = (validFlags >> 8) | (validPower << 2);
-
   unlock_i2c_write();
   i2cWriteReg8(SW35XX_QC_CONF1, conf1);
   i2cWriteReg8(SW35XX_QC_CONF2, conf2);
@@ -242,7 +234,6 @@ void SW35xx::setMaxCurrentsFixed(uint32_t ma_5v, uint32_t ma_9v, uint32_t ma_12v
   unlock_i2c_write();
 
   i2cWriteReg8(SW35XX_PD_CONF8, tmp);
-
   i2cWriteReg8(SW35XX_PD_CONF1, ma_5v/50);
   i2cWriteReg8(SW35XX_PD_CONF2, ma_9v/50);
   i2cWriteReg8(SW35XX_PD_CONF3, ma_12v/50);
@@ -250,7 +241,6 @@ void SW35xx::setMaxCurrentsFixed(uint32_t ma_5v, uint32_t ma_9v, uint32_t ma_12v
   i2cWriteReg8(SW35XX_PD_CONF5, ma_20v/50);
 
   lock_i2c_write();
-
 }
 
 void SW35xx::setMaxCurrentsPPS(uint32_t ma_pps1, uint32_t ma_pps2) {
@@ -270,14 +260,10 @@ void SW35xx::setMaxCurrentsPPS(uint32_t ma_pps1, uint32_t ma_pps2) {
   else
     tmp |= 0b10000000;
   
-  
   unlock_i2c_write();
-
   i2cWriteReg8(SW35XX_PD_CONF8, tmp);
-
   i2cWriteReg8(SW35XX_PD_CONF6, ma_pps1/50);
   i2cWriteReg8(SW35XX_PD_CONF7, ma_pps2/50);
-
   lock_i2c_write();
 }
 

--- a/src/h1_SW35xx.h
+++ b/src/h1_SW35xx.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <stdint.h>
-#include <Wire.h>
+#include "I2CInterface.h"
 
 #ifndef BIT
 #define BIT(x) (1 << (x))
@@ -60,7 +60,7 @@ private:
     ADC_TEMPERATURE = 6,
   };
 
-  TwoWire &_i2c;
+  I2CInterface &_i2c;
 
   int i2cReadReg8(const uint8_t reg);
   int i2cWriteReg8(const uint8_t reg, const uint8_t data);
@@ -71,12 +71,12 @@ private:
   uint16_t readADCDataBuffer(const enum ADCDataType type);
 
 public:
-  SW35xx(TwoWire &i2c = Wire);
+  // Constructor now accepts any I2CInterface
+  SW35xx(I2CInterface &i2c);
   ~SW35xx();
   void begin();
   /**
    * @brief 读取当前充电状态
-   * 
    */
   void readStatus(const bool useADCDataBuffer=false);
   /**
@@ -85,7 +85,7 @@ public:
   float readTemperature(const bool useADCDataBuffer=false);
   /**
    * @brief 发送PD命令
-   * 
+   *
    * @note 这个芯片似乎可以发送很多种PD命令，但是寄存器文档里只有hardreset. 如果你有PD抓包工具，可以尝试2~15的不同参数，摸索出对应的命令。记得开个pr告诉我!
    */
   void sendPDCmd(PDCmd_t cmd);
@@ -105,33 +105,19 @@ public:
   void setMaxCurrent5A();
    /**
    * @brief 设置固定电压组别的最大输出电流
-   * 
+   *
    * @param ma_xx 各组别的最大输出电流,单位毫安,最小分度50ma,设为0则关闭
    * @note 5v无法关闭
    */
   void setMaxCurrentsFixed(uint32_t ma_5v, uint32_t ma_9v, uint32_t ma_12v, uint32_t ma_15v, uint32_t ma_20v);
   /**
    * @brief 设置PPS组别的最大输出电流
-   * 
+   *
    * @param ma_xxx 各组别最大输出电流,单位毫安,最小分度50ma,设为0则关闭
    * @note 注意 PD 配置的最大功率大于 60W 时, pps1 将不会广播 (TODO:datasheet这么写的，没试过)
    *       pps1 的最高电压需要大于 pps0 的最高电压，否则 pps1 不会广播;
    */
   void setMaxCurrentsPPS(uint32_t ma_pps1, uint32_t ma_pps2);
-  /**
-  //  * @brief 重置最大输出电流
-  //  * 
-  //  * @note 20v组别的电流不会被重置
-  //  */
-  // void resetMaxCurrents();
-  // /**
-  //  * @brief 启用Emarker检测
-  //  */
-  // void enableEmarker();
-  // /**
-  //  * @brief 禁用Emarker检测
-  //  */
-  // void disableEmarker();
 public:
   /**
    * @brief 输入电压
@@ -157,12 +143,6 @@ public:
    * @brief PD版本(2或者3)
    */
   uint8_t PDVersion;
-
-public:
-//TODO
-
-private:
-  bool _last_config_read_success;
 };
 
 } // namespace h1_SW35xx


### PR DESCRIPTION
I've updated the SW35xx library to make it more flexible when dealing with multiple devices that share the same fixed I²C address. Instead of being tied to a TwoWire object, the library now accepts any I²C interface via a new abstract class. I added two wrappers—one for TwoWire (hardware I²C) and one for SoftwareWire (software I²C)—so you can easily use either.

The main reason for this change was that I wanted to connect multiple SW35xx devices simultaneously without running into address conflicts. With this refactor, you can now use separate I²C instances (like using SoftwareWire for additional buses) to handle multiple devices without needing an I²C multiplexer.

Let me know if you have any questions or suggestions!